### PR TITLE
Update express-handlebars version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "compression": "^1.4.1",
     "express": "^4.12.0",
-    "express-handlebars": "^1.2.1",
+    "express-handlebars": "^2.0.1",
     "glob": "^4.4.0",
     "handlebars": "^3.0.0",
     "lodash.assign": "^3.0.0",


### PR DESCRIPTION
Express-handlebars `v1.2.1` requires Handlebars `v2.0.0` which has a `1.7M` folder called coverage in it, `v2.0.1` adds the `/coverage` folder to the `.npmignore` - making the required install/download for this smaller.

:smile: 
