### PR TITLE
Removed styles for .sg-container so that css can be agnostic to width

### DIFF
--- a/client/styleguide.css
+++ b/client/styleguide.css
@@ -233,8 +233,3 @@
 .sg-all body {
     padding-top: 0.5em;
 }
-
-.sg-container {
-    max-width: 960px;
-    margin: 0 auto;
-}


### PR DESCRIPTION
Designers should not be restricted to max-width: 960px. Removed all css for .sg-container to keep style guide agnostic to width.
